### PR TITLE
Fix Angular bootstrap by adding zone.js polyfill

### DIFF
--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,1 +1,7 @@
 /** Polyfills for legacy browsers **/
+
+// Angular relies on Zone.js for change detection. Without importing it the
+// application fails to bootstrap and shows the NG0908 error.  Including the
+// library here ensures Angular patches async APIs properly.
+import 'zone.js';
+


### PR DESCRIPTION
## Summary
- import Zone.js in polyfills

## Testing
- `npx --prefix frontend ng build`

------
https://chatgpt.com/codex/tasks/task_e_6883d8adaef08332ac2139e087de53c7